### PR TITLE
Add Block endpoints

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { AddressResource } from "@/resources/address";
 import { AlkaneResource } from "@/resources/alkane";
+import { BlockResource } from "@/resources/block";
 import { Brc20Resource } from "@/resources/brc20";
 import { CollectionResource } from "@/resources/collection";
 import { InscriptionResource } from "@/resources/inscription";
@@ -24,6 +25,7 @@ export class Ordiscan {
 
   public readonly address: AddressResource;
   public readonly alkane: AlkaneResource;
+  public readonly block: BlockResource;
   public readonly tx: TxResource;
   public readonly inscription: InscriptionResource;
   public readonly rune: RuneResource;
@@ -40,6 +42,7 @@ export class Ordiscan {
     // Initialize resources
     this.address = new AddressResource(this);
     this.alkane = new AlkaneResource(this);
+    this.block = new BlockResource(this);
     this.tx = new TxResource(this);
     this.inscription = new InscriptionResource(this);
     this.rune = new RuneResource(this);

--- a/src/resources/block.ts
+++ b/src/resources/block.ts
@@ -1,0 +1,22 @@
+import { BaseResource } from "@/resources/base";
+
+import { Block, RuneTxids } from "@/schemas/block";
+
+export class BlockResource extends BaseResource {
+  async getInfo({
+    hashOrHeight,
+  }: {
+    hashOrHeight: string | number;
+  }): Promise<Block> {
+    return this.client.fetch<Block>(`/block/${hashOrHeight}`);
+  }
+
+  async getRuneTxids({
+    hashOrHeight,
+  }: {
+    hashOrHeight: string | number;
+  }): Promise<RuneTxids> {
+    return this.client.fetch<RuneTxids>(`/block/${hashOrHeight}/rune_txids`);
+  }
+}
+

--- a/src/schemas/block.ts
+++ b/src/schemas/block.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+
+export const BlockStatusSchema = z.object({
+  runes_indexed: z.boolean(),
+  inscriptions_indexed: z.boolean(),
+});
+
+export const BlockSchema = z.object({
+  hash: z.string(),
+  height: z.number(),
+  timestamp: z.string(),
+  size: z.number(),
+  weight: z.number(),
+  status: BlockStatusSchema,
+});
+
+export const RuneTxidsSchema = z.array(z.string());
+
+export type BlockStatus = z.infer<typeof BlockStatusSchema>;
+export type Block = z.infer<typeof BlockSchema>;
+export type RuneTxids = z.infer<typeof RuneTxidsSchema>;

--- a/tests/block.test.ts
+++ b/tests/block.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+
+import { BlockSchema, RuneTxidsSchema } from "@/schemas/block";
+
+import { MOCK_BLOCK_INFO, MOCK_RUNE_TXIDS } from "tests/mocks/block";
+
+import { mock, ordiscan } from "tests/utils";
+
+const BLOCK_HEIGHT = 840000;
+
+test("get block info by height", async () => {
+  mock(`/block/${BLOCK_HEIGHT}`)?.reply(200, {
+    data: MOCK_BLOCK_INFO,
+  });
+
+  const block = await ordiscan.block.getInfo({ hashOrHeight: BLOCK_HEIGHT });
+
+  expect(BlockSchema.parse(block)).toBeTruthy();
+  expect(block.height).toBe(BLOCK_HEIGHT);
+});
+
+test("get rune txids by height", async () => {
+  mock(`/block/${BLOCK_HEIGHT}/rune_txids`)?.reply(200, {
+    data: MOCK_RUNE_TXIDS,
+  });
+
+  const txids = await ordiscan.block.getRuneTxids({
+    hashOrHeight: BLOCK_HEIGHT,
+  });
+
+  expect(RuneTxidsSchema.parse(txids)).toBeTruthy();
+  expect(txids.length).toBeGreaterThan(0);
+  expect(typeof txids[0]).toBe("string");
+});
+

--- a/tests/mocks/block.ts
+++ b/tests/mocks/block.ts
@@ -1,0 +1,19 @@
+import { Block, RuneTxids } from "@/schemas/block";
+
+export const MOCK_BLOCK_INFO: Block = {
+  hash: "0000000000000000000320283a032748cef8227873ff4872689bf23f1cda83a5",
+  height: 840000,
+  timestamp: "2024-04-19T23:09:27.000Z",
+  size: 2325617,
+  weight: 3993281,
+  status: {
+    runes_indexed: true,
+    inscriptions_indexed: true,
+  },
+};
+
+export const MOCK_RUNE_TXIDS: RuneTxids = [
+  "2bb85f4b004be6da54f766c17c1e855187327112c231ef2ff35ebad0ea67c69e",
+  "152b928e97bb9e874da1bd4abdf766ae0cdc7a2f260dad5542967cb414c58489",
+  "e79134080a83fe3e0e06ed6990c5a9b63b362313341745707a2bff7d788a1375",
+];


### PR DESCRIPTION
Adds the following methods based on https://ordiscan.com/docs/api#blocks:

- `block.getInfo`
- `block.getRuneTxids`